### PR TITLE
Correctly version in pom, plugin.yml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.elixiumnetwork</groupId>
     <artifactId>PWarp</artifactId>
-    <version>7.3.3-SNAPSHOT</version>
+    <version>2.7</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 main: me.tks.playerwarp.PWarp
 name: PWarp
-version: 2.7
+version: ${project.version}
 api-version: 1.13
 author: The_King_Senne
 softdepend: [Multiverse-Core,GriefPreventionPlugin, Vault]


### PR DESCRIPTION
Currently, the version defined in Maven's pom.xml differs from the actual version in the plugin.yml file. This is annoying and confusing, given the fact that the output file is called PWarp-pomversion.jar.

This PR changes the version defined in the pom.xml to 2.7, and uses Maven's placeholder in the plugin.yml file. Changing the version element in the pom.xml file is enough, the plugin.yml file will be updated accordingly.