### PR TITLE
Fix GriefPrevention name in softdepend

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -3,7 +3,7 @@ name: PWarp
 version: 2.7
 api-version: 1.13
 author: The_King_Senne
-softdepend: [Multiverse-Core,GriefPreventionPlugin, Vault]
+softdepend: [Multiverse-Core, GriefPrevention, Vault]
 commands:
   pwarp:
     description: Main command for playerwarps


### PR DESCRIPTION
The softdepend value uses the name attribute of the depending plugin's plugin.yml file, which is "GriefPrevention", not "GriefPreventionPlugin":

https://github.com/TechFortress/GriefPrevention/blob/master/src/main/resources/plugin.yml#L1