### PR TITLE
ListOther command fix

### DIFF
--- a/src/main/java/me/tks/playerwarp/WarpList.java
+++ b/src/main/java/me/tks/playerwarp/WarpList.java
@@ -317,17 +317,22 @@ public class WarpList implements Serializable {
         OfflinePlayer requested = PlayerUtils.getOfflinePlayerFromName(player, arg);
 
         if (requested == null) return;
-        listOwnedWarps((Player) requested);
+        listOwnedWarps(player, (Player) requested);
+    }
+
+    public void listOwnedWarps(Player player) {
+        listOwnedWarps(player, player);
     }
 
     /**
      * List all warps owned by a player.
      * @param player player that requested
+     * @param target player to list warps from
      */
-    public void listOwnedWarps(Player player) {
+    public void listOwnedWarps(Player player, Player target) {
 
         ArrayList<String> owned = (ArrayList<String>) this.warps.stream()
-            .filter(x -> x.isOwner(player))
+            .filter(x -> x.isOwner(target))
             .map(Warp::getName)
             .collect(Collectors.toList());
 


### PR DESCRIPTION
The `listOwnedWarps` can now differentiate between the requester and the player who to get the data from, to send the data to the right person.

Closes #21 