### PR TITLE
Fixed /pwarp hide <warp> false not working

### DIFF
--- a/src/main/java/me/tks/playerwarp/GuiCatalog.java
+++ b/src/main/java/me/tks/playerwarp/GuiCatalog.java
@@ -33,15 +33,18 @@ public class GuiCatalog {
             ArrayList<Warp> warps = new ArrayList<>();
             warps.add(warp);
             guis.add(new Gui(1, warps));
-            added = true;
+            return;
         }
-        else {
-            for (Gui gui : guis) {
-                if (gui.hasFreeSlot()) {
-                    gui.addItem(warp.getItemStack());
-                    added = true;
-                    break;
-                }
+
+        if (hasItem(warp)) {
+            return;
+        }
+
+        for (Gui gui : guis) {
+            if (gui.hasFreeSlot()) {
+                gui.addItem(warp.getItemStack());
+                added = true;
+                break;
             }
         }
 
@@ -52,6 +55,23 @@ public class GuiCatalog {
             guis.add(gui);
         }
 
+    }
+
+    /**
+     * Checks if warp exists in GUI's
+     * @param warp the warp to check on
+     * @return boolean, true if it already exists
+     */
+    private boolean hasItem(Warp warp) {
+        boolean result = false;
+        for (Gui gui : guis) {
+            Inventory inventory = gui.getInventory();
+            if (inventory.contains(warp.getItemStack())) {
+                result = true;
+                break;
+            }
+        }
+        return result;
     }
 
     /**

--- a/src/main/java/me/tks/playerwarp/Warp.java
+++ b/src/main/java/me/tks/playerwarp/Warp.java
@@ -335,6 +335,8 @@ public class Warp implements Serializable {
 
         if (isHidden) {
             PWarp.gC.removeItem(this);
+        } else {
+            PWarp.gC.addItem(this);
         }
 
         player.sendMessage(ChatColor.GREEN + Messages.HIDDEN_UNHIDDEN.getMessage());


### PR DESCRIPTION
Fixed `/pwarp hide`: The command does remove the item from the GUI on hide, but doesn't add the item back when the warp is made visible again.

The issue was reported in discord.