### PR TITLE
Fixed boolean parsing

### DIFF
--- a/src/main/java/me/tks/playerwarp/PluginConfiguration.java
+++ b/src/main/java/me/tks/playerwarp/PluginConfiguration.java
@@ -187,7 +187,7 @@ public class PluginConfiguration {
         try {
             isOn = PlayerUtils.getBooleanFromUser(player, safety);
         }
-        catch (Exception e) {
+        catch (IllegalArgumentException e) {
             return;
         }
 
@@ -215,7 +215,7 @@ public class PluginConfiguration {
         try {
             state = PlayerUtils.getBooleanFromUser(player, bool);
         }
-        catch (Exception e) {
+        catch (IllegalArgumentException e) {
             return;
         }
 
@@ -703,7 +703,7 @@ public class PluginConfiguration {
         try {
             privacy = PlayerUtils.getBooleanFromUser(sender, boolStr);
         }
-        catch (Exception e) {
+        catch (IllegalArgumentException e) {
             sender.sendMessage(ChatColor.RED + Messages.TRUE_OR_FALSE.getMessage());
             return;
         }

--- a/src/main/java/me/tks/playerwarp/Warp.java
+++ b/src/main/java/me/tks/playerwarp/Warp.java
@@ -327,7 +327,7 @@ public class Warp implements Serializable {
         try {
             hiddenState = PlayerUtils.getBooleanFromUser(player, state);
         }
-        catch (Exception e) {
+        catch (IllegalArgumentException e) {
             return;
         }
 

--- a/src/main/java/me/tks/utils/PlayerUtils.java
+++ b/src/main/java/me/tks/utils/PlayerUtils.java
@@ -140,23 +140,19 @@ public class PlayerUtils {
     /**
      * Converts user input into a boolean with message.
      * @param player player that requested
-     * @param safety string provided by player
+     * @param bool string provided by player
      * @return Boolean provided by player
-     * @throws Exception when player didn't give a boolean
+     * @throws IllegalArgumentException when player didn't give a boolean
      */
-    public static boolean getBooleanFromUser(CommandSender player, String safety) throws Exception {
-
-        boolean bool;
-
-        try {
-            bool = Boolean.parseBoolean(safety);
+    public static boolean getBooleanFromUser(CommandSender player, String bool) throws IllegalArgumentException {
+        if (bool.equalsIgnoreCase("true")) {
+            return true;
         }
-        catch (Exception e) {
-            player.sendMessage(ChatColor.RED + Messages.TRUE_OR_FALSE.getMessage());
-            throw new Exception();
+        if (bool.equalsIgnoreCase("false")) {
+            return false;
         }
-
-        return bool;
+        player.sendMessage(ChatColor.RED + Messages.TRUE_OR_FALSE.getMessage());
+        throw new IllegalArgumentException();
     }
 
     public static double getDoubleFromUser(Player player, String arg) {


### PR DESCRIPTION
`Boolean.parseBoolean()` does not work the same as `Integer.parseInt()`, because it doesn't throw an exception if an invalid String is given. It just returns `false`. This means the in-game error message for not using "true" or "false" when asked for a boolean (example: `/pw hide <name> true/false`) is never fired.

![afbeelding](https://user-images.githubusercontent.com/39677806/216475890-ae631aa8-8377-4cf4-97c7-f8d5abdf1213.png)
