### PR TITLE
NullPointerException: GameProfile's username cannot be null in newer Minecraft versions

### DIFF
--- a/src/main/java/me/tks/playerwarp/DummyPlayer.java
+++ b/src/main/java/me/tks/playerwarp/DummyPlayer.java
@@ -1,0 +1,188 @@
+package me.tks.playerwarp;
+
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.Statistic;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Player;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.UUID;
+
+public class DummyPlayer implements OfflinePlayer {
+
+    // fixes an issue in newer minecraft versions where usernames are expected for skulls
+    private static final String EMPTY_USERNAME = "";
+    private final UUID uuid;
+    private final String name;
+
+    public DummyPlayer(UUID uuid, String name) {
+        this.uuid = uuid;
+        this.name = name;
+    }
+
+    @Override
+    public boolean isOnline() {
+        return false;
+    }
+
+    @Override
+    public String getName() {
+        if (name == null) {
+            return EMPTY_USERNAME;
+        }
+        return name;
+    }
+
+    @Override
+    public UUID getUniqueId() {
+        return uuid;
+    }
+
+    @Override
+    public boolean isBanned() {
+        return false;
+    }
+
+    @Override
+    public boolean isWhitelisted() {
+        return false;
+    }
+
+    @Override
+    public void setWhitelisted(boolean value) {
+        // ignored
+    }
+
+    @Override
+    public Player getPlayer() {
+        return null;
+    }
+
+    @Override
+    public long getFirstPlayed() {
+        return 0;
+    }
+
+    @Override
+    public long getLastPlayed() {
+        return 0;
+    }
+
+    @Override
+    public boolean hasPlayedBefore() {
+        return false;
+    }
+
+    @Override
+    public Location getBedSpawnLocation() {
+        return null;
+    }
+
+    @Override
+    public void incrementStatistic(Statistic statistic) throws IllegalArgumentException {
+        // ignored
+    }
+
+    @Override
+    public void decrementStatistic(Statistic statistic) throws IllegalArgumentException {
+        // ignored
+    }
+
+    @Override
+    public void incrementStatistic(Statistic statistic, int amount) throws IllegalArgumentException {
+        // ignored
+    }
+
+    @Override
+    public void decrementStatistic(Statistic statistic, int amount) throws IllegalArgumentException {
+        // ignored
+    }
+
+    @Override
+    public void setStatistic(Statistic statistic, int newValue) throws IllegalArgumentException {
+        // ignored
+    }
+
+    @Override
+    public int getStatistic(Statistic statistic) throws IllegalArgumentException {
+        return 0;
+    }
+
+    @Override
+    public void incrementStatistic(Statistic statistic, Material material) throws IllegalArgumentException {
+        // ignored
+    }
+
+    @Override
+    public void decrementStatistic(Statistic statistic, Material material) throws IllegalArgumentException {
+        // ignored
+    }
+
+    @Override
+    public int getStatistic(Statistic statistic, Material material) throws IllegalArgumentException {
+        return 0;
+    }
+
+    @Override
+    public void incrementStatistic(Statistic statistic, Material material, int amount) throws IllegalArgumentException {
+        // ignored
+    }
+
+    @Override
+    public void decrementStatistic(Statistic statistic, Material material, int amount) throws IllegalArgumentException {
+        // ignored
+    }
+
+    @Override
+    public void setStatistic(Statistic statistic, Material material, int newValue) throws IllegalArgumentException {
+        // ignored
+    }
+
+    @Override
+    public void incrementStatistic(Statistic statistic, EntityType entityType) throws IllegalArgumentException {
+        // ignored
+    }
+
+    @Override
+    public void decrementStatistic(Statistic statistic, EntityType entityType) throws IllegalArgumentException {
+        // ignored
+    }
+
+    @Override
+    public int getStatistic(Statistic statistic, EntityType entityType) throws IllegalArgumentException {
+        return 0;
+    }
+
+    @Override
+    public void incrementStatistic(Statistic statistic, EntityType entityType, int amount) throws IllegalArgumentException {
+        // ignored
+    }
+
+    @Override
+    public void decrementStatistic(Statistic statistic, EntityType entityType, int amount) {
+        // ignored
+    }
+
+    @Override
+    public void setStatistic(Statistic statistic, EntityType entityType, int newValue) {
+        // ignored
+    }
+
+    @Override
+    public Map<String, Object> serialize() {
+        return Collections.emptyMap();
+    }
+
+    @Override
+    public boolean isOp() {
+        return false;
+    }
+
+    @Override
+    public void setOp(boolean value) {
+        // ignored
+    }
+}

--- a/src/main/java/me/tks/playerwarp/Warp.java
+++ b/src/main/java/me/tks/playerwarp/Warp.java
@@ -778,12 +778,24 @@ public class Warp implements Serializable {
         }
 
         // letsgo struggling with some skulls *insert sad noises here* :D
-        if (guiItem.getType().equals(Material.PLAYER_HEAD)) {
-            if (map.get("skullOwner") != null) {
+        ItemMeta meta = guiItem.getItemMeta();
+        if (meta instanceof SkullMeta) {
+            SkullMeta skullMeta = (SkullMeta) meta;
 
-                SkullMeta meta = (SkullMeta) guiItem.getItemMeta();
-                meta.setOwningPlayer(Bukkit.getOfflinePlayer(UUID.fromString(map.get("skullOwner"))));
-                guiItem.setItemMeta(meta);
+            String uuidString = map.get("skullOwner");
+
+            if (uuidString != null) {
+
+                UUID uuid = UUID.fromString(uuidString);
+                OfflinePlayer offlinePlayer = Bukkit.getOfflinePlayer(uuid);
+
+                if (offlinePlayer.getName() == null) {
+                    // name of game profile can not be null in newer minecraft versions
+                    offlinePlayer = new DummyPlayer(uuid, "");
+                }
+
+                skullMeta.setOwningPlayer(offlinePlayer);
+                guiItem.setItemMeta(skullMeta);
             }
 
         }


### PR DESCRIPTION
Fixes #30 by creating a DummyPlayer (implementation of OfflinePlayer) which returns an empty String instead of null for getName(). This way GameProfile will not throw an error and still work for new and old versions.

This should problaby be fixed upstream though: 
https://github.com/PaperMC/Paper/pull/9770
